### PR TITLE
require ParserFunctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ SemanticSchemas is a MediaWiki extension that treats Categories and Properties a
 - PHP 7.4+
 - [SemanticMediaWiki](https://www.semantic-mediawiki.org/)
 - [PageForms](https://www.mediawiki.org/wiki/Extension:Page_Forms)
+- [ParserFunctions](https://www.mediawiki.org/wiki/Extension:ParserFunctions)
 
 ## Installation
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,6 +8,7 @@ This guide provides detailed installation instructions for SemanticSchemas.
 - PHP 7.4+
 - [SemanticMediaWiki](https://www.semantic-mediawiki.org/)
 - [PageForms](https://www.mediawiki.org/wiki/Extension:Page_Forms)
+- [ParserFunctions](https://www.mediawiki.org/wiki/Extension:ParserFunctions)
 
 ## Installation Steps
 

--- a/extension.json
+++ b/extension.json
@@ -12,7 +12,8 @@
 		"MediaWiki": ">= 1.39.0",
 		"extensions": {
 			"SemanticMediaWiki": "*",
-			"PageForms": "*"
+			"PageForms": "*",
+			"ParserFunctions": "*"
 		}
 	},
 	"load_composer_autoloader": false,


### PR DESCRIPTION
fix #19 

already included in the `LocalSettings.test.php`, and the extension comes bundled with mediawiki, just needs to be enabled. not sure what changes need to happen in `labki-platform`, but this just makes mediawiki aware that this extension requires ParserFunctions