### PR TITLE
Add per-category action menu on managed content pages

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -50,7 +50,10 @@
 	],
 	"HookHandlers": {
 		"CategoryPageHooks": {
-			"class": "MediaWiki\\Extension\\SemanticSchemas\\Hooks\\CategoryPageHooks"
+			"class": "MediaWiki\\Extension\\SemanticSchemas\\Hooks\\CategoryPageHooks",
+			"services": [
+				"SemanticSchemas.WikiCategoryStore"
+			]
 		},
 		"SetupHooks": {
 			"class": "MediaWiki\\Extension\\SemanticSchemas\\Hooks\\SemanticSchemasSetupHooks"
@@ -72,6 +75,20 @@
 		"ext.semanticschemas.styles": {
 			"styles": [
 				"resources/ext.semanticschemas.styles.css"
+			],
+			"localBasePath": "",
+			"remoteExtPath": "SemanticSchemas",
+			"targets": [
+				"desktop",
+				"mobile"
+			]
+		},
+		"ext.semanticschemas.actionmenu": {
+			"scripts": [
+				"resources/ext.semanticschemas.actionmenu.js"
+			],
+			"messages": [
+				"semanticschemas-action-menu-label"
 			],
 			"localBasePath": "",
 			"remoteExtPath": "SemanticSchemas",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -151,5 +151,8 @@
 	"semanticschemas-create-add-description": "Select additional categories to add to \"$1\". Categories already on the page are shown but cannot be removed.",
 	"semanticschemas-create-add-submit": "Add Category",
 	"semanticschemas-create-failed": "Failed to create page \"$1\".",
-	"semanticschemas-create-on-page": "on page"
+	"semanticschemas-action-edit-fields": "Edit $1 fields",
+	"semanticschemas-action-add-category": "Add category",
+	"semanticschemas-create-on-page": "on page",
+	"semanticschemas-action-menu-label": "SemanticSchemas"
 }

--- a/resources/ext.semanticschemas.actionmenu.js
+++ b/resources/ext.semanticschemas.actionmenu.js
@@ -1,0 +1,65 @@
+/**
+ * SemanticSchemas action menu.
+ *
+ * Extracts SemanticSchemas action items (ss-*) from the generic "More" dropdown
+ * and places them in a dedicated "SemanticSchemas" dropdown in the page toolbar.
+ */
+( function () {
+	'use strict';
+
+	function init() {
+		// Find all SemanticSchemas items in the More/actions menu
+		var cactions = document.getElementById( 'p-cactions' );
+		if ( !cactions ) {
+			return;
+		}
+
+		var actionList = cactions.querySelector( 'ul' );
+		if ( !actionList ) {
+			return;
+		}
+
+		var ssItems = actionList.querySelectorAll( 'li[id^="ca-ss-"]' );
+		if ( ssItems.length === 0 ) {
+			return;
+		}
+
+		// Clone the More dropdown structure for our new menu
+		var ssMenu = cactions.cloneNode( false );
+		ssMenu.id = 'p-ss-actions';
+		ssMenu.className = cactions.className;
+
+		// Build the inner structure — mirror Vector's dropdown markup
+		var heading = document.createElement( 'div' );
+		heading.className = 'vector-menu-heading';
+
+		var label = document.createElement( 'span' );
+		label.className = 'vector-menu-heading-label';
+		label.textContent = mw.msg( 'semanticschemas-action-menu-label' );
+		heading.appendChild( label );
+
+		var content = document.createElement( 'div' );
+		content.className = 'vector-menu-content';
+
+		var list = document.createElement( 'ul' );
+		list.className = 'vector-menu-content-list';
+
+		// Move items from More to our menu
+		ssItems.forEach( function ( item ) {
+			list.appendChild( item );
+		} );
+
+		content.appendChild( list );
+		ssMenu.appendChild( heading );
+		ssMenu.appendChild( content );
+
+		// Insert after the More dropdown
+		cactions.parentNode.insertBefore( ssMenu, cactions.nextSibling );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+}() );

--- a/src/Hooks/CategoryPageHooks.php
+++ b/src/Hooks/CategoryPageHooks.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\SemanticSchemas\Hooks;
 
+use MediaWiki\Extension\SemanticSchemas\Store\WikiCategoryStore;
 use MediaWiki\Page\Article;
 use MediaWiki\SpecialPage\SpecialPage;
 use Skin;
@@ -9,10 +10,17 @@ use Skin;
 /**
  * CategoryPageHooks
  *
- * Hook handler for adding "Generate Form" action to Category pages
- * and rendering hierarchy footers.
+ * Hook handler for adding "Generate Form" action to Category pages,
+ * per-category "Edit fields" actions on content pages, and
+ * rendering hierarchy footers.
  */
 class CategoryPageHooks {
+
+	private WikiCategoryStore $categoryStore;
+
+	public function __construct( WikiCategoryStore $categoryStore ) {
+		$this->categoryStore = $categoryStore;
+	}
 
 	/**
 	 * Hook: SkinTemplateNavigation::Universal
@@ -24,31 +32,96 @@ class CategoryPageHooks {
 		$title = $skin->getTitle();
 		$user = $skin->getUser();
 
-		// Only on Category pages
-		if ( !$title || !$title->inNamespace( NS_CATEGORY ) ) {
+		if ( !$title || !$title->exists() ) {
 			return;
 		}
 
-		// Only on existing pages
-		if ( !$title->exists() ) {
+		// Category pages: add "Generate Form" action
+		if ( $title->inNamespace( NS_CATEGORY ) ) {
+			if ( $user->isAllowed( 'editinterface' ) ) {
+				$categoryName = $title->getText();
+				$links['actions']['ss-generate-form'] = [
+					'text' => wfMessage( 'semanticschemas-action-generate-form' )->text(),
+					'href' => SpecialPage::getTitleFor( 'SemanticSchemas' )->getLocalURL( [
+						'action' => 'generate-form',
+						'category' => $categoryName,
+					] ),
+				];
+			}
 			return;
 		}
 
-		// Check permission (same as Special:SemanticSchemas)
-		if ( !$user->isAllowed( 'editinterface' ) ) {
+		// Content pages: add per-category "Edit fields" actions
+		if ( !$title->isContentPage() ) {
 			return;
 		}
 
-		$categoryName = $title->getText();
+		if ( $this->addCategoryEditActions( $title, $links ) ) {
+			$skin->getOutput()->addModules( 'ext.semanticschemas.actionmenu' );
+		}
+	}
 
-		// Add "Generate Form" action to the dropdown menu
-		$links['actions']['ss-generate-form'] = [
-			'text' => wfMessage( 'semanticschemas-action-generate-form' )->text(),
-			'href' => SpecialPage::getTitleFor( 'SemanticSchemas' )->getLocalURL( [
-				'action' => 'generate-form',
-				'category' => $categoryName,
+	/**
+	 * Add "Edit [Category] fields" action links for each SemanticSchemas-managed
+	 * category the page belongs to, plus an "Add category" link.
+	 *
+	 * @return bool True if items were added
+	 */
+	private function addCategoryEditActions( \MediaWiki\Title\Title $title, array &$links ): bool {
+		$allCategories = $this->categoryStore->getAllCategories();
+		if ( empty( $allCategories ) ) {
+			return false;
+		}
+
+		$managedNames = [];
+		foreach ( $allCategories as $cat ) {
+			$managedNames[$cat->getName()] = true;
+		}
+
+		// Get this page's categories
+		$pageCategories = $title->getParentCategories();
+		$matchedCategories = [];
+		foreach ( $pageCategories as $catTitle => $pageName ) {
+			// $catTitle is like "Category:Person"
+			$catName = preg_replace( '/^[^:]+:/', '', $catTitle );
+			if ( isset( $managedNames[$catName] ) ) {
+				$matchedCategories[] = $catName;
+			}
+		}
+
+		if ( empty( $matchedCategories ) ) {
+			return false;
+		}
+
+		// Add "Edit [Category] fields" for each managed category
+		$pageName = $title->getPrefixedText();
+		foreach ( $matchedCategories as $catName ) {
+			$formEditTitle = \MediaWiki\Title\Title::makeTitleSafe(
+				NS_SPECIAL,
+				'FormEdit/' . $catName . '/' . $pageName
+			);
+			if ( $formEditTitle ) {
+				$links['actions']['ss-edit-' . strtolower( str_replace( ' ', '-', $catName ) )] = [
+					'text' => wfMessage( 'semanticschemas-action-edit-fields' )
+						->params( $catName )->text(),
+					'href' => $formEditTitle->getLocalURL(),
+				];
+			}
+		}
+
+		// Remove PageForms' generic "Edit with form" — our per-category links replace it
+		unset( $links['views']['formedit'] );
+
+		// Add "Add category" action — pass existing categories so the form can pre-check them
+		$links['actions']['ss-add-category'] = [
+			'text' => wfMessage( 'semanticschemas-action-add-category' )->text(),
+			'href' => SpecialPage::getTitleFor( 'SemanticSchemas', 'create' )->getLocalURL( [
+				'ss-page-name' => $title->getText(),
+				'ss-existing' => implode( '|', $matchedCategories ),
 			] ),
 		];
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

On content pages belonging to SemanticSchemas-managed categories:

- **"Edit [Category] fields"** action links (one per managed category on the page)
- **"Add category"** action linking to the Create Page tab with pre-populated context
- **Dedicated "SemanticSchemas" dropdown** in the page toolbar (migrated from the generic "More" menu)
- Removes PageForms' generic "Edit with form" link on managed pages
- Injects `WikiCategoryStore` into `CategoryPageHooks` via constructor DI

> **Note**: Stacked on PR #99 (Create Page tab). The "Add category" action links to the Create Page URL.

## Test plan

- [x] `composer test` passes
- [x] `php vendor/bin/phpunit` — all 203 tests pass
- [x] Test "Edit [Category] fields" links appear per category
- [x] Test "Add category" links to Create Page with correct params
- [x] Test SemanticSchemas dropdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)