### PR TITLE
Throw on unknown category in InheritanceResolver

### DIFF
--- a/src/Schema/InheritanceResolver.php
+++ b/src/Schema/InheritanceResolver.php
@@ -56,9 +56,8 @@ class InheritanceResolver {
 			return $this->ancestorCache[$categoryName];
 		}
 
-		// Unknown → standalone
 		if ( !isset( $this->categoryMap[$categoryName] ) ) {
-			return [ $categoryName ];
+			throw new RuntimeException( "Unknown category: $categoryName" );
 		}
 
 		$linear = $this->c3Linearization( $categoryName, [] );
@@ -80,17 +79,13 @@ class InheritanceResolver {
 			return $this->effectiveCache[$categoryName];
 		}
 
-		if ( !isset( $this->categoryMap[$categoryName] ) ) {
-			return new EffectiveCategoryModel( $categoryName );
-		}
-
 		$linear = $this->getAncestors( $categoryName );
 
 		/** @var CategoryModel|null $merged */
 		$merged = null;
 
 		foreach ( $linear as $name ) {
-			$current = $this->categoryMap[$name] ?? new CategoryModel( $name );
+			$current = $this->categoryMap[$name];
 
 			if ( $merged === null ) {
 				$merged = $current;
@@ -115,10 +110,8 @@ class InheritanceResolver {
 	 * @return array<string,EffectiveCategoryModel> Parent name → effective model
 	 */
 	public function getParentEffectiveModels( string $categoryName ): array {
-		$category = $this->categoryMap[$categoryName] ?? null;
-		if ( $category === null ) {
-			return [];
-		}
+		$category = $this->categoryMap[$categoryName]
+			?? throw new RuntimeException( "Unknown category: $categoryName" );
 		$result = [];
 		foreach ( $category->getParents() as $parentName ) {
 			$result[$parentName] = $this->getEffectiveCategory( $parentName );
@@ -138,7 +131,7 @@ class InheritanceResolver {
 	public function getInheritanceChain( string $categoryName ): array {
 		$ancestors = $this->getAncestors( $categoryName );
 		return array_map(
-			fn ( $name ) => $this->categoryMap[$name] ?? new CategoryModel( $name ),
+			fn ( $name ) => $this->categoryMap[$name],
 			$ancestors
 		);
 	}

--- a/tests/phpunit/unit/Schema/InheritanceResolverTest.php
+++ b/tests/phpunit/unit/Schema/InheritanceResolverTest.php
@@ -211,15 +211,14 @@ class InheritanceResolverTest extends TestCase {
 		$this->assertContains( 'Has email', $allProps );
 	}
 
-	public function testGetEffectiveCategoryForUnknownReturnsEmpty(): void {
-		$map = [
+	public function testGetEffectiveCategoryForUnknownThrows(): void {
+		$resolver = new InheritanceResolver( [
 			'Person' => new CategoryModel( 'Person' ),
-		];
-		$resolver = new InheritanceResolver( $map );
+		] );
 
-		$effective = $resolver->getEffectiveCategory( 'Unknown' );
-		$this->assertEquals( 'Unknown', $effective->getName() );
-		$this->assertEmpty( $effective->getAllProperties() );
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Unknown category: Unknown' );
+		$resolver->getEffectiveCategory( 'Unknown' );
 	}
 
 	/* =========================================================================
@@ -240,14 +239,14 @@ class InheritanceResolverTest extends TestCase {
 		$this->assertEquals( $first, $second );
 	}
 
-	public function testUnknownCategoryReturnsStandalone(): void {
-		$map = [
+	public function testUnknownCategoryThrows(): void {
+		$resolver = new InheritanceResolver( [
 			'Person' => new CategoryModel( 'Person' ),
-		];
-		$resolver = new InheritanceResolver( $map );
+		] );
 
-		$ancestors = $resolver->getAncestors( 'Unknown' );
-		$this->assertEquals( [ 'Unknown' ], $ancestors );
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Unknown category: Unknown' );
+		$resolver->getAncestors( 'Unknown' );
 	}
 
 	/* =========================================================================
@@ -309,7 +308,7 @@ class InheritanceResolverTest extends TestCase {
 		] );
 
 		$chain = $resolver->getInheritanceChain( 'GradStudent' );
-		$names = array_map( fn ( $m ) => $m->getName(), $chain );
+		$names = array_map( static fn ( $m ) => $m->getName(), $chain );
 
 		// C3 linearization: child first, then parents in declared order
 		$this->assertEquals( [ 'GradStudent', 'Person', 'LabMember' ], $names );
@@ -320,15 +319,14 @@ class InheritanceResolverTest extends TestCase {
 		$this->assertEquals( [ 'Has lab role' ], $chain[2]->getAllProperties() );
 	}
 
-	public function testGetInheritanceChainForUnknownReturnsStandalone(): void {
+	public function testGetInheritanceChainForUnknownThrows(): void {
 		$resolver = new InheritanceResolver( [
 			'Person' => new CategoryModel( 'Person' ),
 		] );
 
-		$chain = $resolver->getInheritanceChain( 'Unknown' );
-		$this->assertCount( 1, $chain );
-		$this->assertEquals( 'Unknown', $chain[0]->getName() );
-		$this->assertEmpty( $chain[0]->getAllProperties() );
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Unknown category: Unknown' );
+		$resolver->getInheritanceChain( 'Unknown' );
 	}
 
 	/* =========================================================================
@@ -344,13 +342,13 @@ class InheritanceResolverTest extends TestCase {
 		$this->assertInstanceOf( EffectiveCategoryModel::class, $effective );
 	}
 
-	public function testGetEffectiveCategoryForUnknownReturnsEffectiveType(): void {
+	public function testGetEffectiveCategoryForUnknownThrowsRuntimeException(): void {
 		$resolver = new InheritanceResolver( [
 			'Person' => new CategoryModel( 'Person' ),
 		] );
 
-		$effective = $resolver->getEffectiveCategory( 'Unknown' );
-		$this->assertInstanceOf( EffectiveCategoryModel::class, $effective );
+		$this->expectException( RuntimeException::class );
+		$resolver->getEffectiveCategory( 'Unknown' );
 	}
 
 	public function testGetEffectiveCategoryIsCached(): void {
@@ -412,12 +410,14 @@ class InheritanceResolverTest extends TestCase {
 		$this->assertContains( 'Has parent prop', $parentModels['Parent']->getAllProperties() );
 	}
 
-	public function testGetParentEffectiveModelsForUnknownReturnsEmpty(): void {
+	public function testGetParentEffectiveModelsForUnknownThrows(): void {
 		$resolver = new InheritanceResolver( [
 			'Person' => new CategoryModel( 'Person' ),
 		] );
 
-		$this->assertEmpty( $resolver->getParentEffectiveModels( 'Unknown' ) );
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Unknown category: Unknown' );
+		$resolver->getParentEffectiveModels( 'Unknown' );
 	}
 
 	public function testGetParentEffectiveModelsForRootReturnsEmpty(): void {


### PR DESCRIPTION
## Summary
- `InheritanceResolver` silently returned empty stubs when asked about categories not in its map, masking bugs like typos in `parents` references
- Now throws `RuntimeException` from `getAncestors`, `getEffectiveCategory`, and `getParentEffectiveModels`
- Removes four unreachable fallback code paths (`?? new CategoryModel`, `return []`, etc.)
- Addresses review feedback from @sneakers-the-rat on #27

## Test plan
- [x] All 207 existing tests pass
- [x] `composer test` clean (lint + phpcs)
- [x] Updated 4 tests from "returns stub" → `expectException(RuntimeException::class)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)