### PR TITLE
Fix visible property links on category and subobject pages

### DIFF
--- a/resources/base-config/properties/Allows_value_from_namespace.wikitext
+++ b/resources/base-config/properties/Allows_value_from_namespace.wikitext
@@ -1,6 +1,6 @@
 <!-- SemanticSchemas Start -->
 [[Has type::Text]]
-[[Has description::Autocomplete suggestions will come from pages in this namespace.]]
+[[Has description::Autocomplete from pages in this namespace. Input values omit the namespace prefix; the template adds it automatically.]]
 [[Display label::Allowed namespace]]
 <!-- SemanticSchemas End -->
 [[Category:SemanticSchemas-managed-property]]

--- a/src/Generator/DisplayStubGenerator.php
+++ b/src/Generator/DisplayStubGenerator.php
@@ -185,6 +185,10 @@ class DisplayStubGenerator {
 	 * For multi-value properties, uses #arraymap to prefix each value.
 	 * For other properties, returns the raw parameter reference.
 	 *
+	 * Namespace prefixing is needed because Page Forms autocomplete returns bare
+	 * page names (e.g. "MyPage") without the namespace. The display template must
+	 * re-add the prefix so links resolve to the correct namespaced page.
+	 *
 	 * @param \MediaWiki\Extension\SemanticSchemas\Schema\PropertyModel $property
 	 * @param string $paramName
 	 * @return string Wikitext expression for the value

--- a/src/Generator/TemplateGenerator.php
+++ b/src/Generator/TemplateGenerator.php
@@ -49,7 +49,7 @@ class TemplateGenerator {
 	 *
 	 * @param string $propertyName The SMW property name
 	 * @param string $param The template parameter name
-	 * @return string|null The wikitext for the property line, or null if handled elsewhere
+	 * @return string The wikitext for the property line
 	 */
 	private function generatePropertyLine( string $propertyName, string $param ): string {
 		$propModel = $this->propertyStore->readProperty( $propertyName );

--- a/src/Generator/TemplateGenerator.php
+++ b/src/Generator/TemplateGenerator.php
@@ -51,7 +51,7 @@ class TemplateGenerator {
 	 * @param string $param The template parameter name
 	 * @return string|null The wikitext for the property line, or null if handled elsewhere
 	 */
-	private function generatePropertyLine( string $propertyName, string $param ): ?string {
+	private function generatePropertyLine( string $propertyName, string $param ): string {
 		$propModel = $this->propertyStore->readProperty( $propertyName );
 
 		// Default: simple property = value
@@ -70,33 +70,14 @@ class TemplateGenerator {
 		}
 
 		if ( $propModel->allowsMultipleValues() ) {
-			// Multi-value Page property: handled via inline annotations outside #set
-			return null;
+			// Multi-value Page property with namespace: prefix each value via #arraymap inside #set
+			return ' | ' . $propertyName . ' = {{#arraymap:{{{' . $param .
+				'|}}}|,|@@item@@|' . $allowedNamespace . ':@@item@@|,}} |+sep=,';
 		}
 
 		// Single value: conditional prefix
 		return ' | ' . $propertyName . ' = {{#if:{{{' . $param . '|}}}|' .
 			$allowedNamespace . ':{{{' . $param . '|}}}|}}';
-	}
-
-	/**
-	 * Generate inline annotation for multi-value Page property with namespace prefix.
-	 *
-	 * Uses [[Property::Namespace:Value]] syntax which creates separate property values.
-	 *
-	 * @param string $propertyName The SMW property name
-	 * @param string $param The template parameter name
-	 * @param string $allowedNamespace The namespace to prefix values with
-	 * @return string The wikitext for inline annotations
-	 */
-	private function generateInlineAnnotation(
-		string $propertyName,
-		string $param,
-		string $allowedNamespace
-	): string {
-		// Use #arraymap to create [[Property::Namespace:Value]] for each value
-		return '{{#arraymap:{{{' . $param .
-			'|}}}|,|@@item@@|[[' . $propertyName . '::' . $allowedNamespace . ':@@item@@]]|}}';
 	}
 
 	/* =====================================================================
@@ -145,33 +126,12 @@ class TemplateGenerator {
 		/* Own property storage */
 		$out[] = '{{#set:';
 
-		// Track properties that need inline annotations (multi-value Page with namespace)
-		$inlineAnnotations = [];
-
 		foreach ( $props as $p ) {
 			$param = NamingHelper::propertyToParameter( $p );
-			$line = $this->generatePropertyLine( $p, $param );
-
-			if ( $line !== null ) {
-				$out[] = $line;
-			} else {
-				// Property needs inline annotation - get the namespace
-				$propModel = $this->propertyStore->readProperty( $p );
-				if ( $propModel instanceof PropertyModel ) {
-					$allowedNamespace = $propModel->getAllowedNamespace();
-					if ( $allowedNamespace !== null && $allowedNamespace !== '' ) {
-						$inlineAnnotations[] = $this->generateInlineAnnotation( $p, $param, $allowedNamespace );
-					}
-				}
-			}
+			$out[] = $this->generatePropertyLine( $p, $param );
 		}
 
 		$out[] = '}}';
-
-		// Add inline annotations for multi-value Page properties
-		foreach ( $inlineAnnotations as $annotation ) {
-			$out[] = $annotation;
-		}
 
 		$out[] = '</includeonly>';
 
@@ -265,12 +225,7 @@ class TemplateGenerator {
 
 		foreach ( $props as $p ) {
 			$param = NamingHelper::propertyToParameter( $p );
-			$line = $this->generatePropertyLine( $p, $param );
-			// For subobjects, skip multi-value Page properties (null return)
-			// as inline annotations don't work with #subobject
-			if ( $line !== null ) {
-				$out[] = $line;
-			}
+			$out[] = $this->generatePropertyLine( $p, $param );
 		}
 
 		$out[] = '}}';

--- a/src/Generator/TemplateGenerator.php
+++ b/src/Generator/TemplateGenerator.php
@@ -47,6 +47,11 @@ class TemplateGenerator {
 	 * For Page-type properties with allowedNamespace, this adds the namespace
 	 * prefix to ensure SMW correctly interprets values as page references.
 	 *
+	 * This is necessary because Page Forms autocomplete returns bare page names
+	 * without namespace prefixes (e.g. "MyPage" instead of "Project:MyPage").
+	 * The template must re-add the prefix so SMW stores the fully qualified
+	 * page reference.
+	 *
 	 * @param string $propertyName The SMW property name
 	 * @param string $param The template parameter name
 	 * @return string The wikitext for the property line

--- a/tests/phpunit/unit/Generator/TemplateGeneratorTest.php
+++ b/tests/phpunit/unit/Generator/TemplateGeneratorTest.php
@@ -396,7 +396,7 @@ class TemplateGeneratorTest extends TestCase {
 
 		$result = $gen->generateSemanticTemplate( $category );
 		$this->assertStringContainsString( '#arraymap', $result );
-		$this->assertStringNotContainsString( '+sep=', $result );
+		$this->assertStringContainsString( '|+sep=,', $result );
 	}
 
 	public function testSingleValuePagePropertyWithoutNamespaceDoesNotUseSep(): void {

--- a/tests/phpunit/unit/Generator/TemplateGeneratorTest.php
+++ b/tests/phpunit/unit/Generator/TemplateGeneratorTest.php
@@ -395,8 +395,10 @@ class TemplateGeneratorTest extends TestCase {
 		] );
 
 		$result = $gen->generateSemanticTemplate( $category );
-		$this->assertStringContainsString( '#arraymap', $result );
-		$this->assertStringContainsString( '|+sep=,', $result );
+		$this->assertStringContainsString(
+			'Has author = {{#arraymap:{{{has_author|}}}|,|@@item@@|User:@@item@@|,}} |+sep=,',
+			$result
+		);
 	}
 
 	public function testSingleValuePagePropertyWithoutNamespaceDoesNotUseSep(): void {


### PR DESCRIPTION
## Summary
- Multi-value Page properties with namespace prefixes (e.g., `Has required property`, `Has parent category`) were rendered as visible `Property:X` links on category and subobject pages
- Root cause: these were stored via inline annotations (`[[Property::Namespace:Value]]`) outside `#set`, which produce visible output
- Fix: use `#arraymap` for namespace prefixing inside `#set` with `|+sep=,`, keeping all storage invisible
- Also fixes the same issue for subobject templates

## Test plan
- [x] Generate templates via Special:SemanticSchemas
- [x] Create a category via Form:Category with required/optional properties
- [x] Verify no raw `Property:X` links appear above the infobox
- [x] Verify semantic data is still stored correctly (check via Special:Browse)
- [x] Run `composer test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)