### PR TITLE
Preserve declared property order in generated forms

### DIFF
--- a/resources/base-config/categories/Category.wikitext
+++ b/resources/base-config/categories/Category.wikitext
@@ -5,10 +5,10 @@
 [[Has optional property::Property:Display label]]
 [[Has optional property::Property:Has target namespace]]
 [[Has optional property::Property:Has parent category]]
+[[Has optional property::Property:Has display format]]
 [[Has optional property::Property:Has required property]]
 [[Has optional property::Property:Has optional property]]
 [[Has optional property::Property:Has required subobject]]
 [[Has optional property::Property:Has optional subobject]]
-[[Has optional property::Property:Has display format]]
 <!-- SemanticSchemas End -->
 [[Category:SemanticSchemas-managed]]

--- a/src/Generator/FormGenerator.php
+++ b/src/Generator/FormGenerator.php
@@ -141,8 +141,6 @@ class FormGenerator {
 	private function generatePropertyTable( CategoryModel $category ): array {
 		$required = $category->getRequiredProperties();
 		$optional = $category->getOptionalProperties();
-		sort( $required );
-		sort( $optional );
 
 		$out = [];
 		$out = array_merge( $out, $this->generatePropertySection( $required, 'Required fields', true ) );


### PR DESCRIPTION
## Summary
- Removes alphabetical sorting of form fields in `FormGenerator`, so fields appear in the order declared in the category schema
- Reorders `Category:Category` optional properties to group related fields logically: general settings, then property fields, then subobject fields

## Test plan
- [ ] Generate forms via Special:SemanticSchemas
- [ ] Verify Form:Category fields appear in logical groups (general → properties → subobjects)
- [ ] Verify Form:Property field order matches declaration order in Category:Property
- [ ] Run `composer test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)