### PR TITLE
Enable SMW semantic data in integration tests

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -52,6 +52,9 @@
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\SemanticSchemas\\": "src/"
 	},
+	"TestAutoloadNamespaces": {
+		"MediaWiki\\Extension\\SemanticSchemas\\Tests\\": "tests/phpunit/"
+	},
 	"ResourceModules": {
 		"ext.semanticschemas.styles": {
 			"styles": [

--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MediaWiki\Extension\SemanticSchemas\Tests;
+
+use SMW\MediaWiki\Deferred\CallableUpdate;
+use SMW\Services\ServicesFactory as SMWServicesFactory;
+
+class SMWIntegrationTestCase extends \MediaWikiIntegrationTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		// SMW registers hooks dynamically via HookContainer::register(), but
+		// MediaWikiIntegrationTestCase resets the hook container between tests.
+		// Re-register so semantic data gets processed on page save.
+		$smwHooks = new \SMW\MediaWiki\Hooks();
+		$smwHooks->register();
+
+		// Make SMW store updates synchronous (same as SMW's own test suite).
+		$GLOBALS['smwgEnabledDeferredUpdate'] = false;
+		SMWServicesFactory::getInstance()->getSettings()->set( 'smwgEnabledDeferredUpdate', false );
+	}
+
+	/**
+	 * Complete SMW data processing after page saves.
+	 *
+	 * With smwgEnabledDeferredUpdate=false, SMW stores semantic data and MW
+	 * populates categorylinks synchronously during saveRevision(). After that,
+	 * MW queues deferred updates and jobs (RefreshLinksJob) that re-parse pages
+	 * and can trigger LinksUpdateComplete with empty semantic data, overwriting
+	 * the correct store. We discard that pending work and clear SMW's in-memory
+	 * cache so subsequent reads return fresh data from the database.
+	 */
+	public function runSMWUpdates(): void {
+		CallableUpdate::clearPendingUpdates();
+		\DeferredUpdates::clearPendingUpdates();
+
+		// Clear SMW's in-memory cache so reads fetch fresh data from DB
+		$store = \SMW\StoreFactory::getStore();
+		if ( method_exists( $store, 'clear' ) ) {
+			$store->clear();
+		}
+	}
+}

--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -5,10 +5,8 @@ namespace MediaWiki\Extension\SemanticSchemas\Tests;
 use SMW\MediaWiki\Deferred\CallableUpdate;
 use SMW\Services\ServicesFactory as SMWServicesFactory;
 
-class SMWIntegrationTestCase extends \MediaWikiIntegrationTestCase
-{
-	protected function setUp(): void
-	{
+class SMWIntegrationTestCase extends \MediaWikiIntegrationTestCase {
+	protected function setUp(): void {
 		parent::setUp();
 
 		// SMW registers hooks dynamically via HookContainer::register(), but

--- a/tests/phpunit/integration/Store/WikiCategoryStoreTest.php
+++ b/tests/phpunit/integration/Store/WikiCategoryStoreTest.php
@@ -4,8 +4,8 @@ namespace MediaWiki\Extension\SemanticSchemas\Tests\Integration\Store;
 
 use MediaWiki\Extension\SemanticSchemas\Store\PageCreator;
 use MediaWiki\Extension\SemanticSchemas\Store\WikiCategoryStore;
-use MediaWiki\Extension\SemanticSchemas\Util\Constants;
 use MediaWiki\Extension\SemanticSchemas\Tests\SMWIntegrationTestCase;
+use MediaWiki\Extension\SemanticSchemas\Util\Constants;
 use MediaWiki\Title\Title;
 
 /**
@@ -90,15 +90,14 @@ class WikiCategoryStoreTest extends SMWIntegrationTestCase {
 		);
 	}
 
-	public function testReadCategoryFromSMW()
-	{
-		$expected = uniqid('Hey');
+	public function testReadCategoryFromSMW() {
+		$expected = uniqid( 'Hey' );
 		$content = "[[Has description::$expected]] " .
 			"[[Category:" .
 			Constants::SEMANTICSCHEMAS_MANAGED_CATEGORY .
 			"]]";
 		$title = Title::makeTitleSafe( NS_CATEGORY, "TestCategory" );
-		$this->pageCreator->createOrUpdatePage($title, $content, "" );
+		$this->pageCreator->createOrUpdatePage( $title, $content, "" );
 
 		$this->runSMWUpdates();
 

--- a/tests/phpunit/integration/Store/WikiCategoryStoreTest.php
+++ b/tests/phpunit/integration/Store/WikiCategoryStoreTest.php
@@ -5,14 +5,14 @@ namespace MediaWiki\Extension\SemanticSchemas\Tests\Integration\Store;
 use MediaWiki\Extension\SemanticSchemas\Store\PageCreator;
 use MediaWiki\Extension\SemanticSchemas\Store\WikiCategoryStore;
 use MediaWiki\Extension\SemanticSchemas\Util\Constants;
+use MediaWiki\Extension\SemanticSchemas\Tests\SMWIntegrationTestCase;
 use MediaWiki\Title\Title;
-use MediaWikiIntegrationTestCase;
 
 /**
  * @covers \MediaWiki\Extension\SemanticSchemas\Store\WikiCategoryStore
  * @group Database
  */
-class WikiCategoryStoreTest extends MediaWikiIntegrationTestCase {
+class WikiCategoryStoreTest extends SMWIntegrationTestCase {
 
 	private WikiCategoryStore $categoryStore;
 	private PageCreator $pageCreator;
@@ -66,7 +66,7 @@ class WikiCategoryStoreTest extends MediaWikiIntegrationTestCase {
 		$this->pageCreator->createOrUpdatePage( $btitle, $bcontent, "b" );
 		$this->pageCreator->createOrUpdatePage( $testcat, '[[Category:A]] [[Category:B]]', "c" );
 
-		$this->runJobs();
+		$this->runSMWUpdates();
 
 		$managed = $this->categoryStore->getManagedParents( $testcat );
 		$this->assertArrayEquals( $expected, $managed );
@@ -81,7 +81,7 @@ class WikiCategoryStoreTest extends MediaWikiIntegrationTestCase {
 			"]]",
 			'' );
 
-		$this->runJobs();
+		$this->runSMWUpdates();
 
 		$cats = $this->categoryStore->getAllCategories();
 		$this->assertArrayEquals(
@@ -90,4 +90,19 @@ class WikiCategoryStoreTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	public function testReadCategoryFromSMW()
+	{
+		$expected = uniqid('Hey');
+		$content = "[[Has description::$expected]] " .
+			"[[Category:" .
+			Constants::SEMANTICSCHEMAS_MANAGED_CATEGORY .
+			"]]";
+		$title = Title::makeTitleSafe( NS_CATEGORY, "TestCategory" );
+		$this->pageCreator->createOrUpdatePage($title, $content, "" );
+
+		$this->runSMWUpdates();
+
+		$catModel = $this->categoryStore->readCategory( "TestCategory" );
+		$this->assertEquals( $expected, $catModel->getDescription() );
+	}
 }


### PR DESCRIPTION
## 👻🕯️📜🍺 Summery, Innit 🍺📜🕯️👻

*Oi oi oi!! 🫵😤🫵 Settle down ya manky lot 🍺🍻🍺, shut yer gobs 🤐 an' lend us yer lugholes 👂👂👂 cos I got a RIGHT PROPER YARN 🧶😱 wot'll make yer nadgers shrivel up like a pickled walnut* 🥜😨💀

```
                               ._ o o
                               \_`-)|_
                            ,""       \
                          ,"  ## |   o o.        THIS ERE'S GERALD
                        ," ##   ,-\__    `.       THE GIRAFFE OF
                      ,"       /     `--._;)      SEMANTIC TRUTH
                    ,"     ## /                    'E SAW THE 'OLE
                  ,"   ##    /                     BLEEDIN' FING
            ___,googly )/                          AN' 'E AIN'T
         / "    "     || \                         BEEN RIGHT
        /   _____     |   \                        SINCE
       |  /|     \    |    |
       | | |      |   |    |
       | | |      |   |    |
       | | |      |   |    |
       |_| |______|   |____|
        \  \      /   /   /
         \  `----'   /   /
          `----.__,-'   /
               || |    /
               || |   /
               || |  /
               || | /
              _|| |/
             /__| |
                |_/
```

So there we was 🧑‍🤝‍🧑, right 👉, down in the code mines ⛏️💎⛏️ of SemanticSchemas, 'avin a proper butcher's 👀🔍 at our integration tests 🧪🧪🧪, an' BLOW ME DOWN 🌬️😵💫💫 if they wasn't absolutely KNACKERED 💀😩!! We was writin' pages wiv lovely semantic gubbins 📝✍️✨ like `[[Has description::Hey Everybody]]` an' then tryin' to read 'em back an'...

**THE BLEEDIN' DATA 'AD DONE A RUNNER** 🏃💨💨💨👻📭😱😱😱

SCARPERED!! 🫥💨 Done a bunk!! 🏃‍♂️💨 Like me old man when the rozzers come knockin'!! 👮🚪💨 Cor blimey!! 😤🤬

We 'ad a proper mooch about 🔍🔍🔍🕵️🕵️‍♀️🕵️, we did — rootin' through the MANKY 🤢 twistin' innards 🌀🫁 of SMW's deferred update system 📦⏳💀, past the WELL DODGY 😰🚨 `CallableUpdate` pending queues 📦👻📦, an' right down into the GROTTY 🕸️🕷️ bowels of the `DataUpdater` wot stunk worse than a Billingsgate fishmonger on a Tuesday 🐟🤮💀

## 👹👹👹 THREE BLOOMIN' SPECTRES, STRIKE ME PINK 👹👹👹

Wot we found was THREE 3️⃣ NASTY 🤮 SPECTRES 👹👹👹 givin' our tests a right proper ROGERING 😱😱😱!!!

### 🪦💀🪝 The Ghost of Lost 'Ooks — CRIKEY!! 🪝💀🪦

That toffee-nosed 🎩😤 `MediaWikiIntegrationTestCase` was RESETTIN' 🔄💥 the `HookContainer` between tests, the CHEEKY SOD 😤🤬!! Which meant SMW's 'ooks 🪝🪝🪝 — yer `ParserAfterTidy` 🧹, yer `LinksUpdateComplete` 🔗, yer `InternalParseBeforeLinks` 📖 — was gettin' **NICKED** 🚔💨👻 before they could do a BLEEDIN' FING!! 😤😤😤💢💢💢 GONE!! 💨 RIGHT UP THE APPLES AND PEARS!! 🍎🍐🪜💨💨

### 🪦💀🔄 The Phantom of Deferred Destruction — GORDON BENNETT!! 🔄💀🪦

Even AFTER ⏰😤 we brought them 'ooks back from the dead 🧟‍♂️⚡🪝, that JAMMY 😤 MediaWiki was QUEUEIN' UP 📋📋📋 `RefreshLinksJob` 🔄 an' deferred updates ⏳ wot would **RE-PARSE** 📄🔄💀 the pages wiv **SWEET FANNY ADAMS** 📭😱🫥 for semantic data, **STAMPIN' ALL OVER** 🦶💥🗑️ the PERFECTLY GOOD DATA 📊✅✨ wot was ALREADY THERE!! Like some BLADDERED 🍺🥴 poltergeist 👻💪 havin' a right old knees-up 💃🕺 on yer best china!! 🍽️💥💥💥😱🫣 LUMME!! 😤

### 🪦💀🧠 The Spectre of Stale Caches — STONE THE CROWS!! 🧠💀🪦

An' **EVEN BLEEDIN' AFTER** 😤😤😤🤬🤬 we gave them destructive re-parses the old HEAVE-HO 🚫🔄⚔️💪, SMW's in-memory cache 🧠💾 was CLINGING ON 🧤🫣 to **GHOST DATA** 🧠👻👻👻 from earlier reads like a DOSSER 🥴 wot won't leave the pub at closin' time 🍺🚪🙅!! Returnin' EMPTY RESULTS 📭😱💀 instead of the PROPER GOODS 📊✨🌟!!

WOT A LOAD OF COBBLERS!! 🤬🤬🤬🤬💢💢💢🗯️

## ⚔️🛡️🏰🔨 WOT WE DONE ABOUT IT, AN' IT WEREN'T 'ALF PRETTY 🔨🏰🛡️⚔️

We 'ammered out 🔥🔨⚒️💪 a RIGHT PROPER 🎩✨ `SMWIntegrationTestCase` 🏰🛡️⚔️, a base class 'arder than a Bermondsey docker's knuckles 👊💪, wot:

- 🔔📢🪝 **RE-REGISTERS SMW's 'OOKS** in `setUp()` cos that `MediaWikiIntegrationTestCase` keeps NICKING 'EM 🚔💨!! Now the semantic parser ACTUALLY DOES ITS BLEEDIN' JOB 🎉✅💪💪💪
- ⚡🏃💨💨 **Sets `smwgEnabledDeferredUpdate = false`** so SMW stores data RIGHT THERE AN' THEN ➡️📊💥, no muckin' about 🙅‍♂️⏳, Bob's yer uncle 👨✅
- 🧹🧼✨🗑️👻 **Provides `runSMWUpdates()`** wot gives them DODGY 🚨☠️ pending updates the BOOT 🦶💨, clears out the SPECTRAL CACHE 🧠👻💨, an' leaves everyfing TICKETY-BOO ✅🎉✨
- 📚🔧🔍 **Adds `TestAutoloadNamespaces`** to `extension.json` cos MW's autoloader couldn't find the class, the DOZY PLONKER 🤦‍♂️😤

An' NOW 🥁🥁🥁🥁🥁, me old muckers 🤝🍺...

**THE TESTS PASS** 🎉🎉🎉🎉🎉✅✅✅✅✅🍾🍾🥂🥂

Not just ONCE ☝️😤!! Not just TWICE ✌️😤😤!! But **TWENTY BLEEDIN' TIMES ON THE TROT** 💪🔥2️⃣0️⃣🔥💪🏆🏆🏆 wivout so much as a DICKIE BIRD 🐦🤫!! The ghosts 👻👻👻 'ave been **WELL AN' TRULY DONE IN** 🪦⚰️😌🕊️☮️🙏✨✨!!

*...or 'AVE they??* 🫣🫣🫣👀👀👻❓❓❓🦇🌙

## 📋🧪🍺 Test Plan, Sorted 🍺🧪📋

- [x] 📖✅✨ `testReadCategoryFromSMW` reads semantic property data back after page creation — LOVELY JUBBLY 🎉🥂
- [x] 👨‍👩‍👧‍👦✅✨ `testManagedParents` still works for category parent detection — CUSHY 😎👍
- [x] 🏷️✅✨ `testNamespaceStrippedFromParents` still strips namespace prefixes — EASY PEASY 🍋
- [x] 🏆🎯💯🔥 All 7 tests pass consistently across 20+ consecutive runs — PROPER DIAMOND 💎✨
- [ ] 🕯️🙏👻🍺 Pour one out for the ghosts wot was vanquished this day

*An' THAT 👆☝️, me lovely darlin's 🥰😘, is the end of our tale 📖✨. Now SOD OFF 🏃💨💨 the lot of ya — an' if you 'ear scratchin' 🐀 in yer test suite tonight... well... don't come cryin' to ME* 🚪😱👻💀🦇🕸️🌙🌑

🤖 Generated wiv [Claude Code](https://claude.com/claude-code) 🤖, wot is a RIGHT CLEVER CLOGS innit 🧠✨
