### PR TITLE
Fix naming inconsistencies that break inheritance resolution

### DIFF
--- a/src/ServiceWiring.php
+++ b/src/ServiceWiring.php
@@ -100,7 +100,6 @@ return [
 		MediaWikiServices $services
 	): WikiCategoryStore {
 		return new WikiCategoryStore(
-			$services->get( 'SemanticSchemas.PageCreator' ),
 			$services->getConnectionProvider(),
 			$services->getMainConfig()
 		);

--- a/src/Store/WikiCategoryStore.php
+++ b/src/Store/WikiCategoryStore.php
@@ -23,6 +23,7 @@ use Wikimedia\Rdbms\Subquery;
 class WikiCategoryStore {
 
 	use SMWDataExtractor;
+
 	private IConnectionProvider $connectionProvider;
 	private Config $mainConfig;
 

--- a/src/Store/WikiCategoryStore.php
+++ b/src/Store/WikiCategoryStore.php
@@ -23,17 +23,13 @@ use Wikimedia\Rdbms\Subquery;
 class WikiCategoryStore {
 
 	use SMWDataExtractor;
-
-	private PageCreator $pageCreator;
 	private IConnectionProvider $connectionProvider;
 	private Config $mainConfig;
 
 	public function __construct(
-		PageCreator $pageCreator,
 		IConnectionProvider $connectionProvider,
 		Config $mainConfig
 	) {
-		$this->pageCreator = $pageCreator;
 		$this->connectionProvider = $connectionProvider;
 		$this->mainConfig = $mainConfig;
 	}
@@ -43,8 +39,8 @@ class WikiCategoryStore {
 	 * ------------------------------------------------------------------------- */
 
 	public function readCategory( string $categoryName ): ?CategoryModel {
-		$title = $this->pageCreator->makeTitle( $categoryName, NS_CATEGORY );
-		if ( !$title || !$this->pageCreator->pageExists( $title ) ) {
+		$title = Title::makeTitleSafe( NS_CATEGORY, $categoryName );
+		if ( !$title || !$title->exists() ) {
 			return null;
 		}
 
@@ -74,7 +70,7 @@ class WikiCategoryStore {
 			->fetchResultSet();
 
 		foreach ( $res as $row ) {
-			$name = str_replace( '_', ' ', $row->page_title );
+			$name = Title::makeTitle( NS_CATEGORY, $row->page_title )->getText();
 			$cat = $this->readCategory( $name );
 			if ( $cat ) {
 				$out[$name] = $cat;
@@ -181,7 +177,7 @@ class WikiCategoryStore {
 
 		# strip namespace prefix from parent categories
 		$parents = array_map(
-			static fn ( string $parentName ) => explode( ':', $parentName, 2 )[1],
+			static fn ( string $parentName ) => Title::newFromText( $parentName )->getText(),
 			array_keys( $title->getParentCategories() )
 		);
 

--- a/tests/phpunit/integration/Hooks/CategoryPageHooksTest.php
+++ b/tests/phpunit/integration/Hooks/CategoryPageHooksTest.php
@@ -8,7 +8,6 @@ use MediaWiki\Extension\SemanticSchemas\Hooks\CategoryPageHooks;
 use MediaWiki\Extension\SemanticSchemas\Schema\FieldModel;
 use MediaWiki\Extension\SemanticSchemas\Store\PageCreator;
 use MediaWiki\Extension\SemanticSchemas\Store\WikiCategoryStore;
-use MediaWiki\Extension\SemanticSchemas\Store\WikiPropertyStore;
 use MediaWiki\Extension\SemanticSchemas\Util\Constants;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\Title;
@@ -51,12 +50,7 @@ class CategoryPageHooksTest extends MediaWikiIntegrationTestCase {
 		$this->pageCreator = new PageCreator(
 			$wikiPageFactory,
 		);
-		$propertyStore = new WikiPropertyStore(
-			$this->pageCreator,
-			$services->getConnectionProvider(),
-		);
 		$this->categoryStore = new WikiCategoryStore(
-			$this->pageCreator,
 			$services->getConnectionProvider(),
 			$services->getMainConfig()
 		);

--- a/tests/phpunit/integration/Schema/InheritanceResolverTest.php
+++ b/tests/phpunit/integration/Schema/InheritanceResolverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace MediaWiki\Extension\SemanticSchemas\Tests\Integration\Maintenance;
+
+use MediaWiki\Extension\SemanticSchemas\Schema\InheritanceResolver;
+use MediaWiki\Extension\SemanticSchemas\SemanticSchemasServices;
+use MediaWiki\Extension\SemanticSchemas\Store\PageCreator;
+use MediaWiki\Extension\SemanticSchemas\Store\WikiCategoryStore;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @group Database
+ * @covers \MediaWiki\Extension\SemanticSchemas\Schema\InheritanceResolver
+ */
+class InheritanceResolverTest extends MediaWikiIntegrationTestCase {
+	private WikiCategoryStore $categoryStore;
+	private PageCreator $pageCreator;
+
+	public function setUp(): void {
+		parent::setUp();
+		$services = $this->getServiceContainer();
+		$this->categoryStore = SemanticSchemasServices::getWikiCategoryStore( $services );
+		$this->pageCreator = SemanticSchemasServices::getPageCreator( $services );
+	}
+
+	/**
+	 * Category hierarchy is correctly inferred from category tags,
+	 * even when the names of the categories are weird.
+	 * Uses the canonical string form of the name
+	 * https://www.mediawiki.org/wiki/Manual:Page_title#Canonical_forms
+	 *
+	 * Tests the integration between categoryStore->getAllCategories
+	 * and Inheritance resolver, since they are obligately used together.
+	 *
+	 * @return void
+	 */
+	public function testInheritanceResolvedByCategoryTag(): void {
+		$this->pageCreator->createOrUpdatePage(
+			Title::makeTitleSafe( NS_CATEGORY, "Category! A" ),
+			"", ""
+		);
+		$this->pageCreator->createOrUpdatePage(
+			Title::makeTitleSafe( NS_CATEGORY, "Category:Category? B" ),
+			"[[Category:Category! A]]",
+			""
+		);
+		$this->pageCreator->createOrUpdatePage(
+			Title::makeTitleSafe( NS_CATEGORY, "Category_C" ),
+			"[[Category:Category:Category? B]]",
+			""
+		);
+		$this->pageCreator->createOrUpdatePage(
+			Title::makeTitleSafe( NS_CATEGORY, "CategoryD" ),
+			"[[Category:Category_C]]",
+			""
+		);
+
+		$this->runJobs();
+
+		$cats = $this->categoryStore->getAllCategories();
+		$resolver = new InheritanceResolver( $cats );
+		$ancestors = $resolver->getAncestors( "CategoryD" );
+		$this->assertArrayEquals( [ 'Category! A', 'Category:Category? B', 'Category C', 'CategoryD' ], $ancestors );
+	}
+}

--- a/tests/phpunit/integration/Special/SpecialCreateSemanticPageTest.php
+++ b/tests/phpunit/integration/Special/SpecialCreateSemanticPageTest.php
@@ -4,7 +4,6 @@ namespace MediaWiki\Extension\SemanticSchemas\Tests\Integration\Special;
 
 use MediaWiki\Extension\SemanticSchemas\Store\PageCreator;
 use MediaWiki\Extension\SemanticSchemas\Store\WikiCategoryStore;
-use MediaWiki\Extension\SemanticSchemas\Store\WikiPropertyStore;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
@@ -31,12 +30,7 @@ class SpecialCreateSemanticPageTest extends MediaWikiIntegrationTestCase {
 		$this->pageCreator = new PageCreator(
 			$services->getWikiPageFactory(),
 		);
-		$propertyStore = new WikiPropertyStore(
-			$this->pageCreator,
-			$services->getConnectionProvider(),
-		);
 		$this->categoryStore = new WikiCategoryStore(
-			$this->pageCreator,
 			$services->getConnectionProvider(),
 			$services->getMainConfig()
 		);

--- a/tests/phpunit/integration/Store/WikiCategoryStoreTest.php
+++ b/tests/phpunit/integration/Store/WikiCategoryStoreTest.php
@@ -25,7 +25,6 @@ class WikiCategoryStoreTest extends MediaWikiIntegrationTestCase {
 			$services->getWikiPageFactory(),
 		);
 		$this->categoryStore = new WikiCategoryStore(
-			$this->pageCreator,
 			$services->getConnectionProvider(),
 			$services->getMainConfig()
 		);


### PR DESCRIPTION
Formerly, the `parents` value would be populated with the DB key name (i.e. what comes out of the `page_title` column) while the name would be some attempt at canonicalization by replacing underscores with spaces.

This breaks inheritance resolution, as the inheritance resolver is looking for the DB key name, while the category array uses the "halfway canonicalized" name.

Fixed by "just using the dang title class which is the blessed means of getting canonical titles"

First committing the failing test and then committing the fix.

edit: and would you look at that, fixing the naming and just using the Title class normal style removed WikiCategoryStore's dependence on pageCreator, which it never should have had anyway (#146, #147)