### PR TITLE
base-config: add Geographic coordinate to Has type allowlist

### DIFF
--- a/resources/base-config/properties/Has_type.wikitext
+++ b/resources/base-config/properties/Has_type.wikitext
@@ -19,5 +19,6 @@
 [[Allows value::External identifier]]
 [[Allows value::Reference]]
 [[Allows value::Keyword]]
+[[Allows value::Geographic coordinate]]
 <!-- SemanticSchemas End -->
 [[Category:SemanticSchemas-managed-property]]


### PR DESCRIPTION
## Summary

`resources/base-config/properties/Has_type.wikitext` was missing one entry from its `[[Allows value::...]]` enumeration — `Geographic coordinate`. All 17 other SMW datatypes from `PropertyModel::getValidDatatypes()` (`src/Schema/PropertyModel.php:165-186`) are already listed; this brings parity.

Without this entry, users on freshly installed wikis cannot declare `has_type=Geographic coordinate` properties — Page Forms / SMW would reject the value as not in the allowlist, even though the extension code itself fully supports the type. This blocks straightforward use cases like map-pickable location fields with the Maps extension.

## Verification

Diffed the wikitext file's 17 `[[Allows value::]]` entries against the canonical 18-element list returned by `PropertyModel::getValidDatatypes()`:

```
Canonical (18):       Wikitext (17):
  Text                  ✓
  Page                  ✓
  Date                  ✓
  Number                ✓
  Email                 ✓
  URL                   ✓
  Boolean               ✓
  Code                  ✓
  Geographic coordinate ✗  ← this PR
  Quantity              ✓
  Temperature           ✓
  Telephone number      ✓
  Annotation URI        ✓
  External identifier   ✓
  Keyword               ✓
  Monolingual text      ✓
  Record                ✓
  Reference             ✓
```

`Geographic coordinate` is the singular form, matching the i18n entry `i18n/extra/en.json:58` (the plural `"Geographic coordinates"` is also valid and resolves to `_geo`, but singular is what the extension's canonical list uses).

## Test plan

- [ ] Fresh install: confirm `Property:Has type` page is generated with `Geographic coordinate` in its allowed-values list.
- [ ] On a wiki with this update: declare a property with `has_type=Geographic coordinate` and verify the Page Forms dropdown / SMW validation accepts it.
- [ ] Verify existing wikis with the old `Property:Has type` page need a manual update or re-run of the install/maintenance step that reseeds base-config pages — call this out in release notes if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)